### PR TITLE
Make docker-compose config environment-independent

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-HDIV_AGENT=/Users/Manuel/Dev/workspace/hdiv-enterprise/hdiv-ee-agent/target/hdiv-ee-agent.jar
-HDIV_CONFIG=/Users/Manuel/Dev/workspace/vertx-vulnerable-musicstore/musicstore/hdiv/conf/
-
-HTTP_PORT=8081
-JAVA_OPTS=-Xmx2G -Djava.awt.headless=true -javaagent:/hdiv/hdiv-ee-agent.jar -Dhdiv.config.dir=/hdiv/config -Dhdiv.file.level=FINER -Dhdiv.toolbar.enabled=true -Dhdiv.agent.plain.save=true -Dhdiv.single.app=true

--- a/README.adoc
+++ b/README.adoc
@@ -20,33 +20,24 @@ image::album-page.png[Album]
 
 == Runnning
 
+=== With Docker
+
 If you only want to try the application without modifying it, run the build and start the components with `docker-compose`.
 
 [source,shell]
 ----
+# Set path to hdiv agent
+export HDIV_AGENT=/absoute/path/to/hdiv-ee-agent.jar
+# If you have an Hdiv license, copy it to the config dir
+cp license.hdiv hdiv/conf/
+
 mvn clean package
 docker-compose up
 ----
 
 When all components are up browse to http://localhost:8080.
 
-Otherwise start each component individually.
-
-=== The Postgres database
-
-[source,shell]
-----
-docker run --rm --name musicstore-db -e POSTGRES_USER=music -e POSTGRES_PASSWORD=music -e POSTGRES_DB=musicdb -p 5432:5432 postgres
-----
-
-=== The MongoDB server
-
-[source,shell]
-----
-docker run --rm --name musicstore-mongo -p 27017:27017 mongo
-----
-
-=== Development
+=== With Maven
 
 * Do one time build to pull the dependencies `mvn clean install`
 * To run the application in foreground do `mvn vertx:run` with redeploy enabled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,19 @@
-version: '2'
+version: '3.6'
 services:
   vertx-musicstore:
     build: .
     volumes:
-      - $HDIV_CONFIG:/hdiv/config
-      - $HDIV_AGENT:/hdiv/hdiv-ee-agent.jar
+      - type: bind
+        source: ${HDIV_CONFIG:-./hdiv/conf}
+        target: /hdiv/config
+      - type: bind
+        source: ${HDIV_AGENT}
+        target: /hdiv/hdiv-ee-agent.jar
+        read_only: true
     environment:
-      - JAVA_OPTS=$JAVA_OPTS
+      - JAVA_OPTS=${JAVA_OPTS}
     ports:
-      - $HTTP_PORT:8080
+      - ${HTTP_PORT:-8080}:8080
     depends_on:
       - "postgres"
       - "mongo"

--- a/src/main/docker/start.sh
+++ b/src/main/docker/start.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-exec java -Dvertx.disableDnsResolver=true ${JAVA_OPTS} -jar ${APP_FILE} -conf ${APP_CONF}
+DEFAULT_JAVA_OPTS="-Dvertx.disableDnsResolver=true -Xmx2G -Djava.awt.headless=true -javaagent:/hdiv/hdiv-ee-agent.jar -Dhdiv.config.dir=/hdiv/config -Dhdiv.file.level=FINER -Dhdiv.toolbar.enabled=true -Dhdiv.agent.plain.save=true -Dhdiv.single.app=true"
+JAVA_OPTS="${DEFAULT_JAVA_OPTS} ${JAVA_OPTS:-}"
+set -x
+exec java ${JAVA_OPTS} -jar "${APP_FILE}" -conf "${APP_CONF}"


### PR DESCRIPTION
Removed custom `.env`. Required configuration such as JAVA_OPTS has
defaults in the Docker command at `src/main/docker/start.sh`.

Only the `HDIV_AGENT` environment variable is now required, all the
others are optional.